### PR TITLE
Run automatic_link_headers_for_swift_package.sh to update include for…

### DIFF
--- a/Source/ObjectiveDropboxOfficial/include/DBFILESCommitInfoWithProperties.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBFILESCommitInfoWithProperties.h
@@ -1,1 +1,0 @@
-../Shared/Generated/ApiObjects/Files/Headers/DBFILESCommitInfoWithProperties.h

--- a/Source/ObjectiveDropboxOfficial/include/DBFILESMoveIntoFamilyError.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBFILESMoveIntoFamilyError.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/Files/Headers/DBFILESMoveIntoFamilyError.h

--- a/Source/ObjectiveDropboxOfficial/include/DBFILESUploadArg.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBFILESUploadArg.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/Files/Headers/DBFILESUploadArg.h

--- a/Source/ObjectiveDropboxOfficial/include/DBFILESUploadErrorWithProperties.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBFILESUploadErrorWithProperties.h
@@ -1,1 +1,0 @@
-../Shared/Generated/ApiObjects/Files/Headers/DBFILESUploadErrorWithProperties.h

--- a/Source/ObjectiveDropboxOfficial/include/DBFILESUploadSessionAppendError.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBFILESUploadSessionAppendError.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/Files/Headers/DBFILESUploadSessionAppendError.h

--- a/Source/ObjectiveDropboxOfficial/include/DBFILESUploadSessionStartBatchArg.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBFILESUploadSessionStartBatchArg.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/Files/Headers/DBFILESUploadSessionStartBatchArg.h

--- a/Source/ObjectiveDropboxOfficial/include/DBFILESUploadSessionStartBatchResult.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBFILESUploadSessionStartBatchResult.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/Files/Headers/DBFILESUploadSessionStartBatchResult.h

--- a/Source/ObjectiveDropboxOfficial/include/DBOPENIDAuthError.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBOPENIDAuthError.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/Openid/Headers/DBOPENIDAuthError.h

--- a/Source/ObjectiveDropboxOfficial/include/DBOPENIDErrUnion.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBOPENIDErrUnion.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/Openid/Headers/DBOPENIDErrUnion.h

--- a/Source/ObjectiveDropboxOfficial/include/DBOPENIDUserInfoArgs.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBOPENIDUserInfoArgs.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/Openid/Headers/DBOPENIDUserInfoArgs.h

--- a/Source/ObjectiveDropboxOfficial/include/DBOPENIDUserInfoError.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBOPENIDUserInfoError.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/Openid/Headers/DBOPENIDUserInfoError.h

--- a/Source/ObjectiveDropboxOfficial/include/DBOPENIDUserInfoResult.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBOPENIDUserInfoResult.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/Openid/Headers/DBOPENIDUserInfoResult.h

--- a/Source/ObjectiveDropboxOfficial/include/DBSHARINGAppAuthRoutes.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBSHARINGAppAuthRoutes.h
@@ -1,0 +1,1 @@
+../Shared/Generated/Routes/DBSHARINGAppAuthRoutes.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGAdminEmailRemindersChangedDetails.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGAdminEmailRemindersChangedDetails.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGAdminEmailRemindersChangedDetails.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGAdminEmailRemindersChangedType.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGAdminEmailRemindersChangedType.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGAdminEmailRemindersChangedType.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGAdminEmailRemindersPolicy.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGAdminEmailRemindersPolicy.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGAdminEmailRemindersPolicy.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDataResidencyMigrationRequestSuccessfulDetails.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDataResidencyMigrationRequestSuccessfulDetails.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGDataResidencyMigrationRequestSuccessfulDetails.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDataResidencyMigrationRequestSuccessfulType.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDataResidencyMigrationRequestSuccessfulType.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGDataResidencyMigrationRequestSuccessfulType.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDataResidencyMigrationRequestUnsuccessfulDetails.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDataResidencyMigrationRequestUnsuccessfulDetails.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGDataResidencyMigrationRequestUnsuccessfulDetails.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDataResidencyMigrationRequestUnsuccessfulType.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDataResidencyMigrationRequestUnsuccessfulType.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGDataResidencyMigrationRequestUnsuccessfulType.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDropboxPasswordsPolicy.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDropboxPasswordsPolicy.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGDropboxPasswordsPolicy.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDropboxPasswordsPolicyChangedDetails.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDropboxPasswordsPolicyChangedDetails.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGDropboxPasswordsPolicyChangedDetails.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDropboxPasswordsPolicyChangedType.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGDropboxPasswordsPolicyChangedType.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGDropboxPasswordsPolicyChangedType.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGExternalDriveBackupEligibilityStatus.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGExternalDriveBackupEligibilityStatus.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGExternalDriveBackupEligibilityStatus.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGExternalDriveBackupEligibilityStatusCheckedDetails.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGExternalDriveBackupEligibilityStatusCheckedDetails.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGExternalDriveBackupEligibilityStatusCheckedDetails.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGExternalDriveBackupEligibilityStatusCheckedType.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGExternalDriveBackupEligibilityStatusCheckedType.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGExternalDriveBackupEligibilityStatusCheckedType.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGExternalDriveBackupStatus.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGExternalDriveBackupStatus.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGExternalDriveBackupStatus.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGExternalDriveBackupStatusChangedDetails.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGExternalDriveBackupStatusChangedDetails.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGExternalDriveBackupStatusChangedDetails.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGExternalDriveBackupStatusChangedType.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMLOGExternalDriveBackupStatusChangedType.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamLog/Headers/DBTEAMLOGExternalDriveBackupStatusChangedType.h

--- a/Source/ObjectiveDropboxOfficial/include/DBTEAMPOLICIESFileProviderMigrationPolicyState.h
+++ b/Source/ObjectiveDropboxOfficial/include/DBTEAMPOLICIESFileProviderMigrationPolicyState.h
@@ -1,0 +1,1 @@
+../Shared/Generated/ApiObjects/TeamPolicies/Headers/DBTEAMPOLICIESFileProviderMigrationPolicyState.h


### PR DESCRIPTION
… Swift Package Manager.

Running the script in the toplevel folder did the trick. This updates all symlinks in the include folder. After that the Swift Package Manager loads the package properly and the compile succeeds.

This has all been tested with a fork on my github account. Probably you will need to change the Package.resolved and also move the tag "7.0.0_spm_fork" or create a new tag and also update Package.swift file.